### PR TITLE
Update Oscillator_server_v2.ino

### DIFF
--- a/ArduSnake/examples/Oscillator_server_v2/Oscillator_server_v2.ino
+++ b/ArduSnake/examples/Oscillator_server_v2/Oscillator_server_v2.ino
@@ -176,6 +176,7 @@ void getCommands()
              value = inputString.toInt();
              state = WAITING_SERVO_ID;
              cmd_ok = true;
+             runCommand();
              //Serial.print(inputString);  //-- For debugging
            }
              
@@ -198,6 +199,7 @@ void getCommands()
          //-- End of frame received correctly
          if (inChar == CMD_END) {
            cmd_ok = true;             //-- The command is ok!
+           runCommand();
          }  
          else {
            cmd_ok = false;   //-- Invalid frame. It will be ignored
@@ -208,6 +210,14 @@ void getCommands()
       
   } //-- End While
   
+   // Refresh the oscillators!
+  for (int i = 0; i < NSERVOS; i++)
+  {
+    osc[i].refresh();
+  }
+}
+
+void runCommand(){ 
   
   //-- If the frame received is ok... process!
   if (cmd_ok) {
@@ -248,12 +258,6 @@ void getCommands()
     
     cmd_ok = false;
   }
-  
-  //-- Refresh the oscillators!
-  for (int i=0; i<NSERVOS; i++) {
-    osc[i].refresh();
-  }  
-  
 }
 
 


### PR DESCRIPTION
These changes avoid lost of messages by the fact that more operations
are done inside the loop. In other words, if a message just does not run
when it is over, it may happen that the buffer has more inputs and a
second message begins to overwrite previous information that has not yet
been executed.
Basically, it will allow the oscillators work in parallel with more
stuff (as happened to SCOPUM) and really the serial port buffer to help
us in order to, though the control cycle is lengthened, the messages are
not lost.